### PR TITLE
Fix the name of the agent in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Freshli Agent: Java
+# Freshli Agent: Syft
 
 This application is used by the [`freshli` CLI](https://github.com/corgibytes/freshli-cli) to detect and process manifest files with the Syft processor.
 


### PR DESCRIPTION
The agent name need to be changed in the README.md from Java to Syft